### PR TITLE
Chore: Dependabot Ignore Patch Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,6 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
This PR Addresses Chore: Dependabot Ignore Patch Updates:
* chore: ignore patch updates
